### PR TITLE
update french translation

### DIFF
--- a/Properties/Strings.fr.resx
+++ b/Properties/Strings.fr.resx
@@ -382,7 +382,7 @@
     <value>Afficher rareté</value>
   </data>
   <data name="Shore Fish" xml:space="preserve">
-    <value>Poisson du large</value>
+    <value>Poisson du littoral</value>
   </data>
   <data name="Shrimplings" xml:space="preserve">
     <value>Jeunes crevettes</value>


### PR DESCRIPTION
french translation for shore fish was wrong and duplicate with the offshore translation poisson du large -> poisson du littoral