### PR TITLE
Some german translations (fish info only) + small fix

### DIFF
--- a/FishingBuddy.csproj
+++ b/FishingBuddy.csproj
@@ -279,6 +279,9 @@
     <None Include="ref\_instructions.txt" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Properties\Strings.de.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Strings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>

--- a/FishingBuddyModule.cs
+++ b/FishingBuddyModule.cs
@@ -337,6 +337,7 @@ namespace Eclipse1807.BlishHUD.FishingBuddy
             _baitPanelLoc.SettingChanged -= this.OnUpdateSettings;
             _dragBaitPanel.SettingChanged -= this.OnUpdateSettings;
             _baitImgSize.SettingChanged -= this.OnUpdateSettings;
+            _baitPanel?.Dispose();
             // Time of Day Settings
             _timeOfDayPanelLoc.SettingChanged -= this.OnUpdateClockLocation;
             _dragTimeOfDayClock.SettingChanged -= this.OnUpdateClockSettings;

--- a/Properties/Strings.de.resx
+++ b/Properties/Strings.de.resx
@@ -1,0 +1,285 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Achievement" xml:space="preserve">
+    <value>Erfolg</value>
+  </data>
+  <data name="Any" xml:space="preserve">
+    <value>Jede(r)</value>
+  </data>
+  <data name="Ascended" xml:space="preserve">
+    <value>Aufgestiegen</value>
+  </data>
+  <data name="Basic" xml:space="preserve">
+    <value>Einfach</value>
+  </data>
+  <data name="Boreal Fish" xml:space="preserve">
+    <value>Kaltwasserfisch</value>
+  </data>
+  <data name="Cavern Fish" xml:space="preserve">
+    <value>Höhlenfisch</value>
+  </data>
+  <data name="Channel Fish" xml:space="preserve">
+    <value>Kanalfisch</value>
+  </data>
+  <data name="Coastal Fish" xml:space="preserve">
+    <value>Küstenfisch</value>
+  </data>
+  <data name="Dawn" xml:space="preserve">
+    <value>Morgendämmerung</value>
+  </data>
+  <data name="Dawn/Dusk" xml:space="preserve">
+    <value>Morgen-/Abenddämmerung</value>
+  </data>
+  <data name="Day" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Deep Fishing Hole" xml:space="preserve">
+    <value>Tiefe Angelstelle</value>
+  </data>
+  <data name="Desert Fish" xml:space="preserve">
+    <value>Wüstenfisch</value>
+  </data>
+  <data name="Dusk" xml:space="preserve">
+    <value>Abenddämmerung</value>
+  </data>
+  <data name="Dusk/Dawn" xml:space="preserve">
+    <value>Abend-/Morgendämmerung</value>
+  </data>
+  <data name="Exotic" xml:space="preserve">
+    <value>Exotisch</value>
+  </data>
+  <data name="Fine" xml:space="preserve">
+    <value>Edel</value>
+  </data>
+  <data name="Fish Eggs" xml:space="preserve">
+    <value>Fischeier</value>
+  </data>
+  <data name="FishFavoredBait" xml:space="preserve">
+    <value>Bevorzugter Köder</value>
+  </data>
+  <data name="FishFishingHole" xml:space="preserve">
+    <value>Angelstelle</value>
+  </data>
+  <data name="FishTimeOfDay" xml:space="preserve">
+    <value>Tageszeit</value>
+  </data>
+  <data name="Freshwater Fish" xml:space="preserve">
+    <value>Süßwasserfisch</value>
+  </data>
+  <data name="Glow Worms" xml:space="preserve">
+    <value>Glühwürmchen</value>
+  </data>
+  <data name="Grotto Fish" xml:space="preserve">
+    <value>Grottenfisch</value>
+  </data>
+  <data name="Haiju Minnows" xml:space="preserve">
+    <value>Haiju-Elritzen</value>
+  </data>
+  <data name="Hidden" xml:space="preserve">
+    <value>Versteckt</value>
+  </data>
+  <data name="HiddenCaught" xml:space="preserve">
+    <value>Bereits gefangen</value>
+  </data>
+  <data name="Junk" xml:space="preserve">
+    <value>Schrott</value>
+  </data>
+  <data name="Lake Fish" xml:space="preserve">
+    <value>Seefisch</value>
+  </data>
+  <data name="Lava Beetles" xml:space="preserve">
+    <value>Lava-Käfer</value>
+  </data>
+  <data name="Leeches" xml:space="preserve">
+    <value>Blutegel</value>
+  </data>
+  <data name="Legendary" xml:space="preserve">
+    <value>Legendär</value>
+  </data>
+  <data name="Lightning Bugs" xml:space="preserve">
+    <value>Leuchtkäfer</value>
+  </data>
+  <data name="Mackerel" xml:space="preserve">
+    <value>Makrele</value>
+  </data>
+  <data name="Masterwork" xml:space="preserve">
+    <value>Meisterwerk</value>
+  </data>
+  <data name="Minnows" xml:space="preserve">
+    <value>Süßwasser-Elritzen</value>
+  </data>
+  <data name="Night" xml:space="preserve">
+    <value>Nacht</value>
+  </data>
+  <data name="Nightcrawlers" xml:space="preserve">
+    <value>Regenwürmer</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>Keine</value>
+  </data>
+  <data name="Noxious Water Fish" xml:space="preserve">
+    <value>Giftwasserfisch</value>
+  </data>
+  <data name="Offshore Fish" xml:space="preserve">
+    <value>Meeresfisch</value>
+  </data>
+  <data name="OpenWater" xml:space="preserve">
+    <value>Offenes Wasser</value>
+  </data>
+  <data name="Polluted Lake Fish" xml:space="preserve">
+    <value>Schmutzwasser-Seefisch</value>
+  </data>
+  <data name="Quarry Fish" xml:space="preserve">
+    <value>Grubenfisch</value>
+  </data>
+  <data name="Ramshorn Snails" xml:space="preserve">
+    <value>Posthornschnecken</value>
+  </data>
+  <data name="Rare" xml:space="preserve">
+    <value>Selten</value>
+  </data>
+  <data name="Rarity" xml:space="preserve">
+    <value>Seltenheit</value>
+  </data>
+  <data name="River Fish" xml:space="preserve">
+    <value>Flussfisch</value>
+  </data>
+  <data name="Saltwater Fish" xml:space="preserve">
+    <value>Salzwasserfisch</value>
+  </data>
+  <data name="Sardines" xml:space="preserve">
+    <value>Sardinen</value>
+  </data>
+  <data name="Scorpions" xml:space="preserve">
+    <value>Skorpione</value>
+  </data>
+  <data name="Shore Fish" xml:space="preserve">
+    <value>Küstenfisch</value>
+  </data>
+  <data name="Shrimplings" xml:space="preserve">
+    <value>Krevetten</value>
+  </data>
+  <data name="Sparkfly Larvae" xml:space="preserve">
+    <value>Funkenschwärmer-Raupen</value>
+  </data>
+  <data name="Volcanic Fish" xml:space="preserve">
+    <value>Vulkanfisch</value>
+  </data>
+</root>


### PR DESCRIPTION
I have added these two changes mostly for myself, but wanted to share here, in case you would be interested to integrate into the main repo.

First one is adding german translation for the fish info shown in the tooltip, which is what I needed mostly. The rest of the UI is not translated, but could be added later (by someone else).
Second one is small fix of issue where bait panel remains visible as leftover even after deactivating the module.